### PR TITLE
env support in @subql/cli

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -18,6 +18,8 @@ export const ENDPOINT_REG = /endpoint:\s*(\[[^\]]+\]|['"`][^'"`]+['"`])/;
 export const ADDRESS_REG = /address\s*:\s*['"]([^'"]+)['"]/;
 export const TOPICS_REG = /topics:\s*(\[[^\]]+\]|['"`][^'"`]+['"`])/;
 export const FUNCTION_REG = /function\s*:\s*['"]([^'"]+)['"]/;
+export const CHAIN_ID_REG = /chainId:\s*(\[[^\]]+\]|['"`][^'"`]+['"`])/;
+export const CAPTURE_CHAIN_ID_REG = /chainId:\s*("([^"]*)"|(?<!")(\d+))/;
 
 export const ACCESS_TOKEN_PATH = path.resolve(
   process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'],

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -248,22 +248,21 @@ export async function prepareManifest(projectPath: string, project: ProjectSpecB
 }
 
 export function addDotEnvConfigCode(manifestData: string): string {
-  // Find the first empty line
-  let insertionPoint = -1;
-  const lines = manifestData.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() === '') {
-      insertionPoint = i + 1; // Insert after the empty line
+  // add dotenv config after imports in project.ts file
+  let snippetCodeIndex = -1;
+  const manifestSections = manifestData.split('\n');
+  for (let i = 0; i < manifestSections.length; i++) {
+    if (manifestSections[i].trim() === '') {
+      snippetCodeIndex = i + 1;
       break;
     }
   }
 
-  // Handle no empty line found scenario
-  if (insertionPoint === -1) {
-    insertionPoint = 0;
+  if (snippetCodeIndex === -1) {
+    snippetCodeIndex = 0;
   }
 
-  const envConfigurationCode = `
+  const envConfigCodeSnippet = `
 import * as dotenv from 'dotenv';
 import path from 'path';
 
@@ -275,9 +274,9 @@ dotenv.config({ path: dotenvPath });
 `;
 
   // Inserting the env configuration code in project.ts
-  const updatedTsProject = `${lines.slice(0, insertionPoint).join('\n') + envConfigurationCode}\n${lines
-    .slice(insertionPoint)
-    .join('\n')}`;
+  const updatedTsProject = `${
+    manifestSections.slice(0, snippetCodeIndex).join('\n') + envConfigCodeSnippet
+  }\n${manifestSections.slice(snippetCodeIndex).join('\n')}`;
   return updatedTsProject;
 }
 
@@ -301,6 +300,7 @@ export async function prepareEnv(projectPath: string, project: ProjectSpecBase):
     }
   }
 
+  //adding env configs
   const envData = `ENDPOINT=${project.endpoint}\nCHAIN_ID=${chainId}`;
   await fs.promises.writeFile(envPath, envData, 'utf8');
   await fs.promises.writeFile(envDevelopPath, envData, 'utf8');

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -13,9 +13,14 @@ import {copySync} from 'fs-extra';
 import rimraf from 'rimraf';
 import git from 'simple-git';
 import {parseDocument, YAMLMap, YAMLSeq} from 'yaml';
-import {BASE_TEMPLATE_URl, ENDPOINT_REG} from '../constants';
+import {BASE_TEMPLATE_URl, CAPTURE_CHAIN_ID_REG, CHAIN_ID_REG, ENDPOINT_REG} from '../constants';
 import {isProjectSpecV1_0_0, ProjectSpecBase} from '../types';
 import {
+  defaultEnvDevelopLocalPath,
+  defaultEnvDevelopPath,
+  defaultEnvLocalPath,
+  defaultEnvPath,
+  defaultGitIgnorePath,
   defaultTSManifestPath,
   defaultYamlManifestPath,
   errorHandle,
@@ -158,6 +163,11 @@ export async function readDefaults(projectPath: string): Promise<string[]> {
 
 export async function prepare(projectPath: string, project: ProjectSpecBase): Promise<void> {
   try {
+    await prepareEnv(projectPath, project);
+  } catch (e) {
+    throw new Error('Failed to prepare read or wrte .env file hile preparing the project');
+  }
+  try {
     await prepareManifest(projectPath, project);
   } catch (e) {
     throw new Error('Failed to prepare read or write manifest while preparing the project');
@@ -172,6 +182,11 @@ export async function prepare(projectPath: string, project: ProjectSpecBase): Pr
   } catch (e) {
     throw new Error('Failed to remove .git from template project');
   }
+  try {
+    await prepareGitIgnore(projectPath);
+  } catch (e) {
+    throw new Error('Failed to prepare read or write .gitignore while preparing the project');
+  }
 }
 
 export async function preparePackage(projectPath: string, project: ProjectSpecBase): Promise<void> {
@@ -181,6 +196,17 @@ export async function preparePackage(projectPath: string, project: ProjectSpecBa
   currentPackage.name = project.name;
   currentPackage.description = project.description ?? currentPackage.description;
   currentPackage.author = project.author;
+  //add build and develop scripts
+  currentPackage.scripts = {
+    ...currentPackage.scripts,
+    build: 'subql codegen && subql build',
+    'build:develop': 'NODE_ENV=develop subql codegen && NODE_ENV=develop subql build',
+  };
+  //add dotenv package for env file support
+  currentPackage.devDependencies = {
+    ...currentPackage.devDependencies,
+    dotenv: 'latest',
+  };
   const newPackage = JSON.stringify(currentPackage, null, 2);
   await fs.promises.writeFile(`${projectPath}/package.json`, newPackage, 'utf8');
 }
@@ -195,12 +221,15 @@ export async function prepareManifest(projectPath: string, project: ProjectSpecB
 
   if (isTs) {
     const tsManifest = (await fs.promises.readFile(tsPath, 'utf8')).toString();
-    //converting string endpoint to array of string.
-    const formattedEndpoint = Array.isArray(project.endpoint)
-      ? JSON.stringify(project.endpoint)
-      : `[ "${project.endpoint}" ]`;
-
-    manifestData = findReplace(tsManifest, ENDPOINT_REG, `endpoint: ${formattedEndpoint}`);
+    //adding env config for endpoint.
+    const formattedEndpoint = `process.env.ENDPOINT!.split(',') as string[] | string`;
+    const endpointUpdatedManifestData = findReplace(tsManifest, ENDPOINT_REG, `endpoint: ${formattedEndpoint}`);
+    const chainIdUpdatedManifestData = findReplace(
+      endpointUpdatedManifestData,
+      CHAIN_ID_REG,
+      `chainId: process.env.CHAIN_ID!`
+    );
+    manifestData = addDotEnvConfigCode(chainIdUpdatedManifestData);
   } else {
     //load and write manifest(project.yaml)
     const yamlManifest = await fs.promises.readFile(yamlPath, 'utf8');
@@ -216,6 +245,80 @@ export async function prepareManifest(projectPath: string, project: ProjectSpecB
     manifestData = clonedData.toString();
   }
   await fs.promises.writeFile(isTs ? tsPath : yamlPath, manifestData, 'utf8');
+}
+
+export function addDotEnvConfigCode(manifestData: string): string {
+  // Find the first empty line
+  let insertionPoint = -1;
+  const lines = manifestData.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === '') {
+      insertionPoint = i + 1; // Insert after the empty line
+      break;
+    }
+  }
+
+  // Handle no empty line found scenario
+  if (insertionPoint === -1) {
+    insertionPoint = 0;
+  }
+
+  const envConfigurationCode = `
+import * as dotenv from 'dotenv';
+import path from 'path';
+
+const mode = process.env.NODE_ENV || 'production';
+
+// Load the appropriate .env file
+const dotenvPath = path.resolve(process.cwd(), \`.env\${mode !== 'production' ? \`.$\{mode}\` : ''}\`);
+dotenv.config({ path: dotenvPath });
+`;
+
+  // Inserting the env configuration code in project.ts
+  const updatedTsProject = `${lines.slice(0, insertionPoint).join('\n') + envConfigurationCode}\n${lines
+    .slice(insertionPoint)
+    .join('\n')}`;
+  return updatedTsProject;
+}
+
+export async function prepareEnv(projectPath: string, project: ProjectSpecBase): Promise<void> {
+  //load and write manifest(project.ts/project.yaml)
+  const envPath = defaultEnvPath(projectPath);
+  const envDevelopPath = defaultEnvDevelopPath(projectPath);
+  const envLocalPath = defaultEnvLocalPath(projectPath);
+  const envDevelopLocalPath = defaultEnvDevelopLocalPath(projectPath);
+
+  let chainId;
+  if (isProjectSpecV1_0_0(project)) {
+    chainId = project.chainId;
+  } else {
+    const tsPath = defaultTSManifestPath(projectPath);
+    const tsManifest = (await fs.promises.readFile(tsPath, 'utf8')).toString();
+
+    const match = tsManifest.match(CAPTURE_CHAIN_ID_REG);
+    if (match) {
+      chainId = match[2];
+    }
+  }
+
+  const envData = `ENDPOINT=${project.endpoint}\nCHAIN_ID=${chainId}`;
+  await fs.promises.writeFile(envPath, envData, 'utf8');
+  await fs.promises.writeFile(envDevelopPath, envData, 'utf8');
+  await fs.promises.writeFile(envLocalPath, envData, 'utf8');
+  await fs.promises.writeFile(envDevelopLocalPath, envData, 'utf8');
+}
+
+export async function prepareGitIgnore(projectPath: string): Promise<void> {
+  //load and write .gitignore
+  const gitIgnorePath = defaultGitIgnorePath(projectPath);
+  const isGitIgnore = fs.existsSync(gitIgnorePath);
+
+  if (isGitIgnore) {
+    let gitIgnoreManifest = (await fs.promises.readFile(gitIgnorePath, 'utf8')).toString();
+    //add local .env files in .gitignore
+    gitIgnoreManifest += `\n# ENV local files\n.env.local\n.env.develop.local`;
+    await fs.promises.writeFile(gitIgnorePath, gitIgnoreManifest, 'utf8');
+  }
 }
 
 export function installDependencies(projectPath: string, useNpm?: boolean): void {

--- a/packages/cli/src/utils/utils.ts
+++ b/packages/cli/src/utils/utils.ts
@@ -5,7 +5,15 @@ import fs, {existsSync, readFileSync} from 'fs';
 import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
-import {DEFAULT_MANIFEST, DEFAULT_TS_MANIFEST} from '@subql/common';
+import {
+  DEFAULT_ENV,
+  DEFAULT_ENV_DEVELOP,
+  DEFAULT_ENV_DEVELOP_LOCAL,
+  DEFAULT_ENV_LOCAL,
+  DEFAULT_GIT_IGNORE,
+  DEFAULT_MANIFEST,
+  DEFAULT_TS_MANIFEST,
+} from '@subql/common';
 import {SubqlRuntimeHandler} from '@subql/common-ethereum';
 import axios from 'axios';
 import cli, {ux} from 'cli-ux';
@@ -256,4 +264,24 @@ export function defaultYamlManifestPath(projectPath: string): string {
 
 export function defaultTSManifestPath(projectPath: string): string {
   return path.join(projectPath, DEFAULT_TS_MANIFEST);
+}
+
+export function defaultEnvPath(projectPath: string): string {
+  return path.join(projectPath, DEFAULT_ENV);
+}
+
+export function defaultEnvDevelopPath(projectPath: string): string {
+  return path.join(projectPath, DEFAULT_ENV_DEVELOP);
+}
+
+export function defaultEnvLocalPath(projectPath: string): string {
+  return path.join(projectPath, DEFAULT_ENV_LOCAL);
+}
+
+export function defaultEnvDevelopLocalPath(projectPath: string): string {
+  return path.join(projectPath, DEFAULT_ENV_DEVELOP_LOCAL);
+}
+
+export function defaultGitIgnorePath(projectPath: string): string {
+  return path.join(projectPath, DEFAULT_GIT_IGNORE);
 }

--- a/packages/common/src/project/utils.ts
+++ b/packages/common/src/project/utils.ts
@@ -24,6 +24,11 @@ export const DEFAULT_MULTICHAIN_MANIFEST = 'subquery-multichain.yaml';
 export const DEFAULT_MULTICHAIN_TS_MANIFEST = 'subquery-multichain.ts';
 export const DEFAULT_MANIFEST = 'project.yaml';
 export const DEFAULT_TS_MANIFEST = 'project.ts';
+export const DEFAULT_ENV = '.env';
+export const DEFAULT_ENV_DEVELOP = '.env.develop';
+export const DEFAULT_ENV_LOCAL = '.env.local';
+export const DEFAULT_ENV_DEVELOP_LOCAL = '.env.develop.local';
+export const DEFAULT_GIT_IGNORE = '.gitignore';
 
 export function isFileReference(value: any): value is FileReference {
   return value?.file && typeof value.file === 'string';


### PR DESCRIPTION
Issue: https://github.com/subquery/subql/issues/2217

# Description
- Created expected .env files and added local env files in .gitignore
```javascript
.env
.env.local 
.env.develop
.env.develop.local
```
Added **CHAIN_ID** and **ENDPOINT**  in all the .env files dynamically fetching from  `project.ts`
```javascript
// Example .env
ENDPOINT=https://opbnb-mainnet-rpc.bnbchain.org,jjj
CHAIN_ID=204
```
User can configure .env files as per there requirement
Multiple ENDPOINT can be added in .env file using comma separated
```javascript
ENDPOINT=https://opbnb-mainnet-rpc.bnbchain.org,jjj,https://polygon.api.onfinality.io/public
```

- Imported dotenv package and added respective config code in `project.ts` for development or production
```javascript
import * as dotenv from 'dotenv';
import path from 'path';

const mode = process.env.NODE_ENV || 'production';
// Load the appropriate .env file
const dotenvPath = path.resolve(process.cwd(), `.env${mode !== 'production' ? `.${mode}` : ''}`);
dotenv.config({ path: dotenvPath });

const project: EthereumProject = {
   .....
  network: {
    chainId: process.env.chainId,
    endpoint: process.env.ENDPOINT!.split(',') as string[] | string,
  },
```
- In `package.json` added scripts for build prod / develop and also added **"dotenv"** in devDependencies
```javascript
  scripts: {
      ......
    "build": "subql codegen && subql build", // default is production
    "build:develop": "NODE_ENV=develop subql codegen && NODE_ENV=develop subql build",
  }
  "devDependencies": {
      .....
    "dotenv": "latest"
  }
 ```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
